### PR TITLE
Add ASP.NET Core task rotation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
-# UserTasks
+# Task Rotation API
+
+This repository contains a minimal ASP.NET Core Web API that manages users and tasks and enforces the rotation rules described in the assignment. Everything is kept in memory to keep the project easy to run and reason about.
+
+## Running the API
+
+1. Install the .NET 8 SDK.
+2. Restore dependencies and run the application:
+
+   ```bash
+   dotnet restore TaskRotationApi
+   dotnet run --project TaskRotationApi
+   ```
+
+3. The API listens on the default ASP.NET ports. When running locally you can browse the interactive Swagger UI at `https://localhost:7091/swagger` (or the HTTP port shown in the console output).
+
+### Configuration
+
+The automatic task rotation runs every two minutes by default. You can override the interval (for example during debugging) by adding the following setting to `appsettings.Development.json` or by setting an environment variable:
+
+```json
+{
+  "TaskRotation": {
+    "IntervalSeconds": 30
+  }
+}
+```
+
+## Available endpoints
+
+All routes are prefixed with `/api`.
+
+### Users
+
+- `GET /api/users` – list all users with the number of currently assigned tasks.
+- `GET /api/users/{id}` – get a single user.
+- `POST /api/users` – create a user. Body: `{ "name": "Alice" }`.
+- `DELETE /api/users/{id}` – delete a user. Any tasks currently assigned to the user move back to the waiting pool.
+
+### Tasks
+
+- `GET /api/tasks` – list all tasks including their state, assignee (if any) and history.
+- `GET /api/tasks/{id}` – get a single task.
+- `POST /api/tasks` – create a task. Body: `{ "title": "Write documentation" }`.
+
+## Behaviour summary
+
+- User names and task titles must be unique.
+- Each user can work on up to three tasks at a time.
+- Tasks are assigned automatically on creation if a suitable user exists. Otherwise, they remain in the waiting state.
+- Every two minutes tasks are rotated to a different user respecting the rules defined in the brief. When no user is available the task returns to the waiting state.
+- A task is marked as completed once it has been assigned to every existing user at least once. Completed tasks are no longer reassigned.
+
+The code includes inline comments and logging explaining the key decisions.

--- a/TaskRotationApi/Controllers/TasksController.cs
+++ b/TaskRotationApi/Controllers/TasksController.cs
@@ -1,0 +1,49 @@
+using Microsoft.AspNetCore.Mvc;
+using TaskRotationApi.Dtos;
+using TaskRotationApi.Services;
+
+namespace TaskRotationApi.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class TasksController : ControllerBase
+{
+    private readonly TaskAssignmentService _service;
+
+    public TasksController(TaskAssignmentService service)
+    {
+        _service = service;
+    }
+
+    [HttpGet]
+    public ActionResult<IReadOnlyCollection<TaskResponse>> GetTasks()
+    {
+        return Ok(_service.GetTasks());
+    }
+
+    [HttpGet("{id:guid}")]
+    public ActionResult<TaskResponse> GetTask(Guid id)
+    {
+        var task = _service.GetTask(id);
+        if (task is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(task);
+    }
+
+    [HttpPost]
+    public ActionResult<TaskResponse> CreateTask([FromBody] CreateTaskRequest request)
+    {
+        var (success, error, task) = _service.CreateTask(request.Title);
+        if (!success)
+        {
+            return string.Equals(error, "A task with the same title already exists.", StringComparison.Ordinal)
+                ? Conflict(new { message = error })
+                : BadRequest(new { message = error });
+        }
+
+        return CreatedAtAction(nameof(GetTask), new { id = task!.Id }, task);
+    }
+}

--- a/TaskRotationApi/Controllers/UsersController.cs
+++ b/TaskRotationApi/Controllers/UsersController.cs
@@ -1,0 +1,61 @@
+using Microsoft.AspNetCore.Mvc;
+using TaskRotationApi.Dtos;
+using TaskRotationApi.Services;
+
+namespace TaskRotationApi.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class UsersController : ControllerBase
+{
+    private readonly TaskAssignmentService _service;
+
+    public UsersController(TaskAssignmentService service)
+    {
+        _service = service;
+    }
+
+    [HttpGet]
+    public ActionResult<IReadOnlyCollection<UserResponse>> GetUsers()
+    {
+        return Ok(_service.GetUsers());
+    }
+
+    [HttpGet("{id:guid}")]
+    public ActionResult<UserResponse> GetUser(Guid id)
+    {
+        var user = _service.GetUser(id);
+        if (user is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(user);
+    }
+
+    [HttpPost]
+    public ActionResult<UserResponse> CreateUser([FromBody] CreateUserRequest request)
+    {
+        var (success, error, user) = _service.CreateUser(request.Name);
+        if (!success)
+        {
+            return string.Equals(error, "A user with the same name already exists.", StringComparison.Ordinal)
+                ? Conflict(new { message = error })
+                : BadRequest(new { message = error });
+        }
+
+        return CreatedAtAction(nameof(GetUser), new { id = user!.Id }, user);
+    }
+
+    [HttpDelete("{id:guid}")]
+    public IActionResult DeleteUser(Guid id)
+    {
+        var (success, error) = _service.DeleteUser(id);
+        if (!success)
+        {
+            return NotFound(new { message = error });
+        }
+
+        return NoContent();
+    }
+}

--- a/TaskRotationApi/Dtos/TaskDtos.cs
+++ b/TaskRotationApi/Dtos/TaskDtos.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+using TaskRotationApi.Models;
+
+namespace TaskRotationApi.Dtos;
+
+public record CreateTaskRequest(
+    [Required, MinLength(1)] string Title
+);
+
+public record TaskResponse(
+    Guid Id,
+    string Title,
+    TaskState State,
+    Guid? AssignedUserId,
+    string? AssignedUserName,
+    IReadOnlyCollection<Guid> AssignmentHistory,
+    DateTimeOffset CreatedAt
+);

--- a/TaskRotationApi/Dtos/UserDtos.cs
+++ b/TaskRotationApi/Dtos/UserDtos.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TaskRotationApi.Dtos;
+
+public record CreateUserRequest(
+    [Required, MinLength(1)] string Name
+);
+
+public record UserResponse(Guid Id, string Name, int ActiveTaskCount);

--- a/TaskRotationApi/Models/TaskItem.cs
+++ b/TaskRotationApi/Models/TaskItem.cs
@@ -1,0 +1,21 @@
+namespace TaskRotationApi.Models;
+
+/// <summary>
+/// Represents a unit of work to be transferred between users.
+/// </summary>
+public class TaskItem
+{
+    public Guid Id { get; init; } = Guid.NewGuid();
+
+    public required string Title { get; set; }
+
+    public TaskState State { get; set; } = TaskState.Waiting;
+
+    public Guid? AssignedUserId { get; set; }
+
+    public Guid? PreviousUserId { get; set; }
+
+    public List<Guid> AssignmentHistory { get; } = new();
+
+    public DateTimeOffset CreatedAt { get; } = DateTimeOffset.UtcNow;
+}

--- a/TaskRotationApi/Models/TaskState.cs
+++ b/TaskRotationApi/Models/TaskState.cs
@@ -1,0 +1,8 @@
+namespace TaskRotationApi.Models;
+
+public enum TaskState
+{
+    Waiting = 0,
+    InProgress = 1,
+    Completed = 2
+}

--- a/TaskRotationApi/Models/User.cs
+++ b/TaskRotationApi/Models/User.cs
@@ -1,0 +1,11 @@
+namespace TaskRotationApi.Models;
+
+/// <summary>
+/// Represents a user that can have tasks assigned.
+/// </summary>
+public class User
+{
+    public Guid Id { get; init; } = Guid.NewGuid();
+
+    public required string Name { get; set; }
+}

--- a/TaskRotationApi/Program.cs
+++ b/TaskRotationApi/Program.cs
@@ -1,0 +1,26 @@
+using TaskRotationApi.Services;
+using TaskRotationApi.Storage;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.AddSingleton<InMemoryDataStore>();
+builder.Services.AddSingleton<TaskAssignmentService>();
+builder.Services.AddHostedService<TaskRotationHostedService>();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.MapControllers();
+
+app.Run();

--- a/TaskRotationApi/Properties/launchSettings.json
+++ b/TaskRotationApi/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "TaskRotationApi": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7091;http://localhost:5091",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/TaskRotationApi/Services/TaskAssignmentService.cs
+++ b/TaskRotationApi/Services/TaskAssignmentService.cs
@@ -1,0 +1,321 @@
+using System.Security.Cryptography;
+using TaskRotationApi.Dtos;
+using TaskRotationApi.Models;
+using TaskRotationApi.Storage;
+
+namespace TaskRotationApi.Services;
+
+/// <summary>
+/// Contains all domain rules for creating users, tasks and orchestrating the
+/// periodic reassignments.
+/// </summary>
+public class TaskAssignmentService
+{
+    private readonly InMemoryDataStore _store;
+    private readonly ILogger<TaskAssignmentService> _logger;
+
+    public TaskAssignmentService(InMemoryDataStore store, ILogger<TaskAssignmentService> logger)
+    {
+        _store = store;
+        _logger = logger;
+    }
+
+    public IReadOnlyCollection<UserResponse> GetUsers()
+    {
+        return _store.Read((users, tasks) =>
+        {
+            var response = new List<UserResponse>(users.Count);
+            foreach (var user in users)
+            {
+                response.Add(MapUser(user, tasks));
+            }
+
+            return response;
+        });
+    }
+
+    public UserResponse? GetUser(Guid id)
+    {
+        return _store.Read((users, tasks) =>
+        {
+            var user = users.FirstOrDefault(u => u.Id == id);
+            return user is null ? null : MapUser(user, tasks);
+        });
+    }
+
+    public (bool Success, string? Error, UserResponse? User) CreateUser(string name)
+    {
+        var trimmed = name.Trim();
+        if (string.IsNullOrWhiteSpace(trimmed))
+        {
+            return (false, "Name is required.", null);
+        }
+
+        return _store.Write((users, tasks) =>
+        {
+            if (users.Any(u => string.Equals(u.Name, trimmed, StringComparison.OrdinalIgnoreCase)))
+            {
+                return (false, "A user with the same name already exists.", (UserResponse?)null);
+            }
+
+            var user = new User
+            {
+                Name = trimmed
+            };
+
+            users.Add(user);
+
+            // Adding a new user may free capacity for waiting tasks.
+            foreach (var task in tasks.Where(t => t.State != TaskState.Completed && t.AssignedUserId is null).ToList())
+            {
+                TryAssignTask(task, users, tasks);
+                TryFinalizeTask(task, users);
+            }
+
+            return (true, null, MapUser(user, tasks));
+        });
+    }
+
+    public (bool Success, string? Error) DeleteUser(Guid id)
+    {
+        return _store.Write((users, tasks) =>
+        {
+            var user = users.FirstOrDefault(u => u.Id == id);
+            if (user is null)
+            {
+                return (false, "User not found.");
+            }
+
+            users.Remove(user);
+
+            foreach (var task in tasks)
+            {
+                if (task.AssignedUserId == id)
+                {
+                    task.AssignedUserId = null;
+                    if (task.PreviousUserId == id)
+                    {
+                        task.PreviousUserId = null;
+                    }
+                    task.State = TaskState.Waiting;
+                }
+                else if (task.PreviousUserId == id)
+                {
+                    task.PreviousUserId = null;
+                }
+
+                TryFinalizeTask(task, users);
+            }
+
+            // Removing a user may also free capacity for waiting tasks if others are idle.
+            foreach (var task in tasks.Where(t => t.State != TaskState.Completed && t.AssignedUserId is null).ToList())
+            {
+                TryAssignTask(task, users, tasks);
+                TryFinalizeTask(task, users);
+            }
+
+            return (true, null);
+        });
+    }
+
+    public IReadOnlyCollection<TaskResponse> GetTasks()
+    {
+        return _store.Read((users, tasks) => tasks.Select(t => MapTask(t, users)).ToList());
+    }
+
+    public TaskResponse? GetTask(Guid id)
+    {
+        return _store.Read((users, tasks) =>
+        {
+            var task = tasks.FirstOrDefault(t => t.Id == id);
+            return task is null ? null : MapTask(task, users);
+        });
+    }
+
+    public (bool Success, string? Error, TaskResponse? Task) CreateTask(string title)
+    {
+        var trimmed = title.Trim();
+        if (string.IsNullOrWhiteSpace(trimmed))
+        {
+            return (false, "Title is required.", null);
+        }
+
+        return _store.Write((users, tasks) =>
+        {
+            if (tasks.Any(t => string.Equals(t.Title, trimmed, StringComparison.OrdinalIgnoreCase)))
+            {
+                return (false, "A task with the same title already exists.", (TaskResponse?)null);
+            }
+
+            var task = new TaskItem
+            {
+                Title = trimmed
+            };
+
+            tasks.Add(task);
+
+            TryAssignTask(task, users, tasks);
+            TryFinalizeTask(task, users);
+
+            return (true, null, MapTask(task, users));
+        });
+    }
+
+    /// <summary>
+    /// Called by the hosted service every two minutes.
+    /// </summary>
+    public void RotateAssignments()
+    {
+        _store.Write((users, tasks) =>
+        {
+            if (users.Count == 0)
+            {
+                foreach (var task in tasks)
+                {
+                    if (task.State != TaskState.Completed)
+                    {
+                        task.AssignedUserId = null;
+                        task.State = TaskState.Waiting;
+                    }
+                }
+                return;
+            }
+
+            foreach (var task in tasks)
+            {
+                if (task.State == TaskState.Completed)
+                {
+                    continue;
+                }
+
+                // The rotation rule requires every task to attempt a reassignment.
+                var previousAssignee = task.AssignedUserId;
+                var assigned = TryAssignTask(task, users, tasks, forceDifferent: true);
+
+                if (!assigned)
+                {
+                    task.AssignedUserId = null;
+                    task.State = TaskState.Waiting;
+                }
+                else if (previousAssignee != task.AssignedUserId)
+                {
+                    _logger.LogInformation("Task {TaskTitle} moved from {PreviousUser} to {CurrentUser}", task.Title, previousAssignee, task.AssignedUserId);
+                }
+
+                TryFinalizeTask(task, users);
+            }
+        });
+    }
+
+    private bool TryAssignTask(TaskItem task, IReadOnlyList<User> users, IReadOnlyList<TaskItem> allTasks, bool forceDifferent = false)
+    {
+        if (task.State == TaskState.Completed)
+        {
+            return false;
+        }
+
+        var activeCounts = new Dictionary<Guid, int>();
+        foreach (var other in allTasks)
+        {
+            if (other.State == TaskState.Completed || other.AssignedUserId is null)
+            {
+                continue;
+            }
+
+            if (!activeCounts.TryGetValue(other.AssignedUserId.Value, out var count))
+            {
+                count = 0;
+            }
+
+            activeCounts[other.AssignedUserId.Value] = count + 1;
+        }
+
+        var candidates = new List<User>();
+        foreach (var user in users)
+        {
+            activeCounts.TryGetValue(user.Id, out var count);
+            if (count >= 3)
+            {
+                continue;
+            }
+
+            if (forceDifferent && task.AssignedUserId == user.Id)
+            {
+                continue;
+            }
+
+            if (task.AssignedUserId == user.Id || task.PreviousUserId == user.Id)
+            {
+                continue;
+            }
+
+            candidates.Add(user);
+        }
+
+        if (candidates.Count == 0)
+        {
+            return false;
+        }
+
+        var historySet = new HashSet<Guid>(task.AssignmentHistory);
+        var unseenCandidates = candidates.Where(c => !historySet.Contains(c.Id)).ToList();
+        var selectionPool = unseenCandidates.Count > 0 ? unseenCandidates : candidates;
+
+        var selected = selectionPool[RandomNumberGenerator.GetInt32(selectionPool.Count)];
+
+        task.PreviousUserId = task.AssignedUserId;
+        task.AssignedUserId = selected.Id;
+        task.State = TaskState.InProgress;
+        task.AssignmentHistory.Add(selected.Id);
+
+        return true;
+    }
+
+    private void TryFinalizeTask(TaskItem task, IReadOnlyList<User> users)
+    {
+        if (task.State == TaskState.Completed)
+        {
+            return;
+        }
+
+        if (users.Count == 0)
+        {
+            task.AssignedUserId = null;
+            task.State = TaskState.Waiting;
+            return;
+        }
+
+        var uniqueHistory = task.AssignmentHistory.Distinct().ToHashSet();
+        var allUsersVisited = users.All(u => uniqueHistory.Contains(u.Id));
+
+        if (allUsersVisited)
+        {
+            task.State = TaskState.Completed;
+            task.PreviousUserId = task.AssignedUserId;
+            task.AssignedUserId = null;
+        }
+    }
+
+    private UserResponse MapUser(User user, IReadOnlyList<TaskItem> tasks)
+    {
+        var activeCount = tasks.Count(t => t.AssignedUserId == user.Id && t.State != TaskState.Completed);
+        return new UserResponse(user.Id, user.Name, activeCount);
+    }
+
+    private TaskResponse MapTask(TaskItem task, IReadOnlyList<User> users)
+    {
+        var assignedUserName = task.AssignedUserId.HasValue
+            ? users.FirstOrDefault(u => u.Id == task.AssignedUserId.Value)?.Name
+            : null;
+
+        return new TaskResponse(
+            task.Id,
+            task.Title,
+            task.State,
+            task.AssignedUserId,
+            assignedUserName,
+            task.AssignmentHistory.AsReadOnly(),
+            task.CreatedAt
+        );
+    }
+}

--- a/TaskRotationApi/Services/TaskRotationHostedService.cs
+++ b/TaskRotationApi/Services/TaskRotationHostedService.cs
@@ -1,0 +1,58 @@
+namespace TaskRotationApi.Services;
+
+/// <summary>
+/// Periodically rotates the task assignments to fulfil the scheduling rules.
+/// </summary>
+public class TaskRotationHostedService : BackgroundService
+{
+    private readonly TaskAssignmentService _service;
+    private readonly ILogger<TaskRotationHostedService> _logger;
+    private readonly TimeSpan _interval;
+
+    public TaskRotationHostedService(TaskAssignmentService service, ILogger<TaskRotationHostedService> logger, IConfiguration configuration)
+    {
+        _service = service;
+        _logger = logger;
+
+        var seconds = configuration.GetValue("TaskRotation:IntervalSeconds", 120);
+        if (seconds < 5)
+        {
+            seconds = 5; // guard against accidentally disabling the loop.
+        }
+
+        _interval = TimeSpan.FromSeconds(seconds);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Task rotation service started. Interval: {Interval}", _interval);
+
+        // Run once at startup so waiting tasks can be picked up immediately.
+        SafeRotate();
+
+        try
+        {
+            await using var timer = new PeriodicTimer(_interval);
+            while (await timer.WaitForNextTickAsync(stoppingToken))
+            {
+                SafeRotate();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // graceful shutdown
+        }
+    }
+
+    private void SafeRotate()
+    {
+        try
+        {
+            _service.RotateAssignments();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to rotate task assignments");
+        }
+    }
+}

--- a/TaskRotationApi/Storage/InMemoryDataStore.cs
+++ b/TaskRotationApi/Storage/InMemoryDataStore.cs
@@ -1,0 +1,38 @@
+using TaskRotationApi.Models;
+
+namespace TaskRotationApi.Storage;
+
+/// <summary>
+/// Small helper that keeps all data in memory and protects it with a lock so the
+/// API controllers and background scheduler do not step on each other.
+/// </summary>
+public class InMemoryDataStore
+{
+    private readonly object _sync = new();
+    private readonly List<User> _users = new();
+    private readonly List<TaskItem> _tasks = new();
+
+    public T Read<T>(Func<IReadOnlyList<User>, IReadOnlyList<TaskItem>, T> reader)
+    {
+        lock (_sync)
+        {
+            return reader(_users, _tasks);
+        }
+    }
+
+    public void Write(Action<List<User>, List<TaskItem>> writer)
+    {
+        lock (_sync)
+        {
+            writer(_users, _tasks);
+        }
+    }
+
+    public T Write<T>(Func<List<User>, List<TaskItem>, T> writer)
+    {
+        lock (_sync)
+        {
+            return writer(_users, _tasks);
+        }
+    }
+}

--- a/TaskRotationApi/TaskRotationApi.csproj
+++ b/TaskRotationApi/TaskRotationApi.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/TaskRotationApi/appsettings.json
+++ b/TaskRotationApi/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "TaskRotation": {
+    "IntervalSeconds": 120
+  }
+}


### PR DESCRIPTION
## Summary
- create an ASP.NET Core Web API project that stores users and tasks in memory
- implement automatic task assignment and rotation rules with background scheduling
- document available endpoints and how to run the service

## Testing
- `dotnet build TaskRotationApi` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68daa4b87960832093390c1963ea1602