### PR TITLE
Add unit tests covering task assignment rules

### DIFF
--- a/TaskRotationApi.Tests/TaskAssignmentServiceTests.cs
+++ b/TaskRotationApi.Tests/TaskAssignmentServiceTests.cs
@@ -1,0 +1,178 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging.Abstractions;
+using TaskRotationApi.Models;
+using TaskRotationApi.Services;
+using TaskRotationApi.Storage;
+using Xunit;
+
+namespace TaskRotationApi.Tests;
+
+public class TaskAssignmentServiceTests
+{
+    [Fact]
+    public void CreateTask_AssignsUser_WhenAvailable()
+    {
+        var service = CreateService(out var store);
+
+        var userId = AddUser(service, "Alice");
+
+        var result = service.CreateTask("Task A");
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Value);
+        Assert.Equal(TaskState.InProgress, result.Value!.State);
+        Assert.Equal(userId, result.Value.AssignedUserId);
+
+        var storedTask = store.Read((_, tasks) => tasks.Single());
+        Assert.Equal(TaskState.InProgress, storedTask.State);
+        Assert.Equal(userId, storedTask.AssignedUserId);
+    }
+
+    [Fact]
+    public void CreateTask_StaysWaiting_WhenNoUsersAvailable()
+    {
+        var service = CreateService(out _);
+
+        var result = service.CreateTask("Task B");
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Value);
+        Assert.Equal(TaskState.Waiting, result.Value!.State);
+        Assert.Null(result.Value.AssignedUserId);
+    }
+
+    [Fact]
+    public void CreateTask_EnforcesMaximumOfThreeActiveTasksPerUser()
+    {
+        var service = CreateService(out var store);
+
+        var userId = AddUser(service, "Bob");
+
+        for (var i = 0; i < 4; i++)
+        {
+            var result = service.CreateTask($"Task {i}");
+            Assert.True(result.Success);
+            Assert.NotNull(result.Value);
+
+            if (i < 3)
+            {
+                Assert.Equal(TaskState.InProgress, result.Value!.State);
+                Assert.Equal(userId, result.Value.AssignedUserId);
+            }
+            else
+            {
+                Assert.Equal(TaskState.Waiting, result.Value!.State);
+                Assert.Null(result.Value.AssignedUserId);
+            }
+        }
+
+        var activeCount = store.Read((_, tasks) => tasks.Count(t => t.AssignedUserId == userId));
+        Assert.Equal(3, activeCount);
+    }
+
+    [Fact]
+    public void RotateAssignments_DoesNotReuseCurrentOrPreviousUser()
+    {
+        var service = CreateService(out var store);
+
+        var user1 = AddUser(service, "User 1");
+        var user2 = AddUser(service, "User 2");
+        var user3 = AddUser(service, "User 3");
+
+        var taskId = Guid.NewGuid();
+        store.Write((users, tasks) =>
+        {
+            tasks.Add(new TaskItem
+            {
+                Id = taskId,
+                Title = "Rotation",
+                State = TaskState.InProgress,
+                AssignedUserId = user1,
+                AssignmentHistory = { user1 }
+            });
+        });
+
+        var firstRotation = service.RotateAssignments();
+        Assert.Single(firstRotation);
+        var firstChange = firstRotation.Single();
+
+        Assert.Equal(taskId, firstChange.TaskId);
+        Assert.Equal(user1, firstChange.FromUserId);
+        Assert.NotNull(firstChange.ToUserId);
+        Assert.NotEqual(user1, firstChange.ToUserId);
+
+        var secondRotation = service.RotateAssignments();
+        Assert.Single(secondRotation);
+        var secondChange = secondRotation.Single();
+
+        Assert.Equal(taskId, secondChange.TaskId);
+        Assert.Equal(firstChange.ToUserId, secondChange.FromUserId);
+        Assert.NotNull(secondChange.ToUserId);
+        Assert.NotEqual(secondChange.FromUserId, secondChange.ToUserId);
+        Assert.NotEqual(user1, secondChange.ToUserId);
+
+        var visitedUsers = new HashSet<Guid>();
+        store.Read((_, tasks) =>
+        {
+            var task = tasks.Single(t => t.Id == taskId);
+            visitedUsers.UnionWith(task.AssignmentHistory);
+            return 0;
+        });
+
+        Assert.Contains(user1, visitedUsers);
+        Assert.Contains(user2, visitedUsers);
+        Assert.Contains(user3, visitedUsers);
+    }
+
+    [Fact]
+    public void RotateAssignments_CompletesTaskAfterAllUsersVisited()
+    {
+        var service = CreateService(out var store);
+
+        var user1 = AddUser(service, "Alpha");
+        var user2 = AddUser(service, "Beta");
+
+        var taskId = Guid.NewGuid();
+        store.Write((users, tasks) =>
+        {
+            tasks.Add(new TaskItem
+            {
+                Id = taskId,
+                Title = "Completion",
+                State = TaskState.InProgress,
+                AssignedUserId = user1,
+                AssignmentHistory = { user1 }
+            });
+        });
+
+        var changes = service.RotateAssignments();
+        Assert.Single(changes);
+
+        var task = store.Read((_, tasks) => tasks.Single(t => t.Id == taskId));
+        Assert.Equal(TaskState.Completed, task.State);
+        Assert.Null(task.AssignedUserId);
+        Assert.Equal(user1, task.PreviousUserId);
+        Assert.Equal(new HashSet<Guid> { user1, user2 }, task.AssignmentHistory.ToHashSet());
+    }
+
+    private static TaskAssignmentService CreateService(out InMemoryDataStore store)
+    {
+        store = new InMemoryDataStore();
+        store.Write((users, tasks) =>
+        {
+            users.Clear();
+            tasks.Clear();
+        });
+
+        return new TaskAssignmentService(store, NullLogger<TaskAssignmentService>.Instance);
+    }
+
+    private static Guid AddUser(TaskAssignmentService service, string name)
+    {
+        var result = service.CreateUser(name);
+        Assert.True(result.Success);
+        Assert.NotNull(result.Value);
+        return result.Value!.Id;
+    }
+}

--- a/TaskRotationApi.Tests/TaskRotationApi.Tests.csproj
+++ b/TaskRotationApi.Tests/TaskRotationApi.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.6.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\TaskRotationApi\TaskRotationApi.csproj" />
+  </ItemGroup>
+</Project>

--- a/TaskRotationApi.sln
+++ b/TaskRotationApi.sln
@@ -2,20 +2,26 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.8.34309.116
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TaskRotationApi", "TaskRotationApi\TaskRotationApi.csproj", "{3CCE0407-9F3F-48E1-AA47-00043ACB5B51}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TaskRotationApi", "TaskRotationApi\\TaskRotationApi.csproj", "{3CCE0407-9F3F-48E1-AA47-00043ACB5B51}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TaskRotationApi.Tests", "TaskRotationApi.Tests\\TaskRotationApi.Tests.csproj", "{05733456-0945-4A07-9B95-8F249F93DCE6}"
 EndProject
 Global
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{3CCE0407-9F3F-48E1-AA47-00043ACB5B51}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3CCE0407-9F3F-48E1-AA47-00043ACB5B51}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3CCE0407-9F3F-48E1-AA47-00043ACB5B51}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3CCE0407-9F3F-48E1-AA47-00043ACB5B51}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
+        GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                Debug|Any CPU = Debug|Any CPU
+                Release|Any CPU = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {3CCE0407-9F3F-48E1-AA47-00043ACB5B51}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {3CCE0407-9F3F-48E1-AA47-00043ACB5B51}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {3CCE0407-9F3F-48E1-AA47-00043ACB5B51}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {3CCE0407-9F3F-48E1-AA47-00043ACB5B51}.Release|Any CPU.Build.0 = Release|Any CPU
+                {05733456-0945-4A07-9B95-8F249F93DCE6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {05733456-0945-4A07-9B95-8F249F93DCE6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {05733456-0945-4A07-9B95-8F249F93DCE6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {05733456-0945-4A07-9B95-8F249F93DCE6}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(SolutionProperties) = preSolution
+                HideSolutionNode = FALSE
+        EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- add a dedicated test project for TaskAssignmentService
- cover task creation limits and rotation logic with new unit tests
- update the solution file to include the new test project

## Testing
- not run (dotnet CLI not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dada3144508320985f11889d7a93c4