### PR TITLE
Add on-demand seeding endpoint and data store

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# UserTasks
+# UserTasks API
+
+This project provides a small ASP.NET Core Web API that exposes an endpoint for seeding in-memory test data on demand.
+
+## Endpoints
+
+- `POST /api/seedTestData` &mdash; Calls `SeedInitialData()` on the singleton `InMemoryDataStore` to populate demo data. The method is not invoked automatically on application startup, so no test data is loaded until this endpoint is called. Subsequent calls return `409 Conflict` to indicate that the data has already been seeded.
+
+## Running the project
+
+1. Restore and build the solution:
+   ```bash
+   dotnet build
+   ```
+2. Run the API:
+   ```bash
+   dotnet run --project src/UserTasks.Api/UserTasks.Api.csproj
+   ```
+3. Seed the data by calling the endpoint:
+   ```bash
+   curl -X POST https://localhost:5001/api/seedTestData
+   ```

--- a/UserTasks.sln
+++ b/UserTasks.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UserTasks.Api", "src/UserTasks.Api/UserTasks.Api.csproj", "{A20554AC-BB70-46DD-BD40-FA604D9C154F}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{A20554AC-BB70-46DD-BD40-FA604D9C154F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{A20554AC-BB70-46DD-BD40-FA604D9C154F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{A20554AC-BB70-46DD-BD40-FA604D9C154F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{A20554AC-BB70-46DD-BD40-FA604D9C154F}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+EndGlobal

--- a/src/UserTasks.Api/Controllers/TestDataController.cs
+++ b/src/UserTasks.Api/Controllers/TestDataController.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Mvc;
+using UserTasks.Api.Services;
+
+namespace UserTasks.Api.Controllers;
+
+[ApiController]
+[Route("api")]
+public class TestDataController : ControllerBase
+{
+    private readonly InMemoryDataStore _dataStore;
+
+    public TestDataController(InMemoryDataStore dataStore)
+    {
+        _dataStore = dataStore;
+    }
+
+    [HttpPost("seedTestData")]
+    public IActionResult SeedTestData()
+    {
+        var seeded = _dataStore.SeedInitialData();
+
+        if (!seeded)
+        {
+            return Conflict(new { message = "Test data has already been seeded." });
+        }
+
+        return Ok(new { message = "Test data seeded successfully." });
+    }
+}

--- a/src/UserTasks.Api/Models/UserTask.cs
+++ b/src/UserTasks.Api/Models/UserTask.cs
@@ -1,0 +1,3 @@
+namespace UserTasks.Api.Models;
+
+public record UserTask(Guid Id, string Title, string Description, DateTime DueDate, bool IsCompleted);

--- a/src/UserTasks.Api/Program.cs
+++ b/src/UserTasks.Api/Program.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using UserTasks.Api.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddSingleton<InMemoryDataStore>();
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+app.UseAuthorization();
+app.MapControllers();
+
+app.Run();

--- a/src/UserTasks.Api/Services/InMemoryDataStore.cs
+++ b/src/UserTasks.Api/Services/InMemoryDataStore.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using UserTasks.Api.Models;
+
+namespace UserTasks.Api.Services;
+
+public class InMemoryDataStore
+{
+    private readonly List<UserTask> _tasks = new();
+    private bool _isSeeded;
+
+    public IReadOnlyCollection<UserTask> Tasks => _tasks.AsReadOnly();
+
+    public bool SeedInitialData()
+    {
+        if (_isSeeded)
+        {
+            return false;
+        }
+
+        _tasks.Clear();
+        _tasks.AddRange(new[]
+        {
+            new UserTask(Guid.NewGuid(), "Write API docs", "Document the seedTestData endpoint", DateTime.UtcNow.AddDays(1), false),
+            new UserTask(Guid.NewGuid(), "Create demo user", "Add a sample user for testing", DateTime.UtcNow.AddDays(2), false),
+            new UserTask(Guid.NewGuid(), "Schedule reminder", "Configure reminder notifications", DateTime.UtcNow.AddDays(3), false)
+        });
+
+        _isSeeded = true;
+        return true;
+    }
+}

--- a/src/UserTasks.Api/UserTasks.Api.csproj
+++ b/src/UserTasks.Api/UserTasks.Api.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add a minimal ASP.NET Core Web API project with an in-memory data store
- expose a POST /api/seedTestData endpoint that calls InMemoryDataStore.SeedInitialData()
- document how to trigger the seeding endpoint so data is not seeded automatically on startup

## Testing
- dotnet build *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db6efc787c83209f0a93984de155b6