### PR TITLE
Implement task assignment workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# UserTasks
+# UserTasks API
+
+This project provides a small ASP.NET Core Web API that exposes an endpoint for seeding in-memory test data on demand.
+
+## Endpoints
+
+- `POST /api/seedTestData` &mdash; Calls `SeedInitialData()` on the singleton `InMemoryDataStore` to populate demo data. The method is not invoked automatically on application startup, so no test data is loaded until this endpoint is called. Subsequent calls return `409 Conflict` to indicate that the data has already been seeded.
+
+## Running the project
+
+1. Restore and build the solution:
+   ```bash
+   dotnet build
+   ```
+2. Run the API:
+   ```bash
+   dotnet run --project src/UserTasks.Api/UserTasks.Api.csproj
+   ```
+3. Seed the data by calling the endpoint:
+   ```bash
+   curl -X POST https://localhost:5001/api/seedTestData
+   ```

--- a/UserTasks.sln
+++ b/UserTasks.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UserTasks.Api", "src/UserTasks.Api/UserTasks.Api.csproj", "{A20554AC-BB70-46DD-BD40-FA604D9C154F}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{A20554AC-BB70-46DD-BD40-FA604D9C154F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{A20554AC-BB70-46DD-BD40-FA604D9C154F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{A20554AC-BB70-46DD-BD40-FA604D9C154F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{A20554AC-BB70-46DD-BD40-FA604D9C154F}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+EndGlobal

--- a/src/UserTasks.Api/Controllers/TestDataController.cs
+++ b/src/UserTasks.Api/Controllers/TestDataController.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Mvc;
+using UserTasks.Api.Services;
+
+namespace UserTasks.Api.Controllers;
+
+[ApiController]
+[Route("api")]
+public class TestDataController : ControllerBase
+{
+    private readonly InMemoryDataStore _dataStore;
+
+    public TestDataController(InMemoryDataStore dataStore)
+    {
+        _dataStore = dataStore;
+    }
+
+    [HttpPost("seedTestData")]
+    public IActionResult SeedTestData()
+    {
+        var seeded = _dataStore.SeedInitialData();
+
+        if (!seeded)
+        {
+            return Conflict(new { message = "Test data has already been seeded." });
+        }
+
+        return Ok(new { message = "Test data seeded successfully." });
+    }
+}

--- a/src/UserTasks.Api/Models/OperationResult.cs
+++ b/src/UserTasks.Api/Models/OperationResult.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace UserTasks.Api.Models;
+
+public class OperationResult<T>
+{
+    private OperationResult(bool success, T? value, string? error)
+    {
+        Success = success;
+        Value = value;
+        Error = error;
+    }
+
+    public bool Success { get; }
+
+    public T? Value { get; }
+
+    public string? Error { get; }
+
+    public static OperationResult<T> Successful(T value)
+    {
+        return new OperationResult<T>(true, value, null);
+    }
+
+    public static OperationResult<T> Failure(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            throw new ArgumentException("An error message is required.", nameof(message));
+        }
+
+        return new OperationResult<T>(false, default, message);
+    }
+}

--- a/src/UserTasks.Api/Models/TaskAssignment.cs
+++ b/src/UserTasks.Api/Models/TaskAssignment.cs
@@ -1,0 +1,57 @@
+using System;
+
+namespace UserTasks.Api.Models;
+
+public class TaskAssignment
+{
+    public TaskAssignment(Guid id, string title, string description)
+    {
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            throw new ArgumentException("Title is required.", nameof(title));
+        }
+
+        if (string.IsNullOrWhiteSpace(description))
+        {
+            throw new ArgumentException("Description is required.", nameof(description));
+        }
+
+        Id = id;
+        Title = title.Trim();
+        Description = description.Trim();
+        CreatedAt = DateTime.UtcNow;
+        State = TaskState.Pending;
+    }
+
+    public Guid Id { get; }
+
+    public string Title { get; }
+
+    public string Description { get; }
+
+    public Guid? AssignedUserId { get; private set; }
+
+    public TaskState State { get; private set; }
+
+    public DateTime CreatedAt { get; }
+
+    public DateTime? CompletedAt { get; private set; }
+
+    public void AssignTo(Guid userId)
+    {
+        AssignedUserId = userId;
+        State = TaskState.InProgress;
+    }
+
+    public void MarkPending()
+    {
+        AssignedUserId = null;
+        State = TaskState.Pending;
+    }
+
+    public void Complete()
+    {
+        State = TaskState.Completed;
+        CompletedAt = DateTime.UtcNow;
+    }
+}

--- a/src/UserTasks.Api/Models/TaskState.cs
+++ b/src/UserTasks.Api/Models/TaskState.cs
@@ -1,0 +1,8 @@
+namespace UserTasks.Api.Models;
+
+public enum TaskState
+{
+    Pending = 0,
+    InProgress = 1,
+    Completed = 2
+}

--- a/src/UserTasks.Api/Models/UserAccount.cs
+++ b/src/UserTasks.Api/Models/UserAccount.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace UserTasks.Api.Models;
+
+public class UserAccount
+{
+    public UserAccount(Guid id, string name, bool isAvailable = true)
+    {
+        Id = id;
+        Name = name;
+        IsAvailable = isAvailable;
+    }
+
+    public Guid Id { get; }
+
+    public string Name { get; }
+
+    public bool IsAvailable { get; private set; }
+
+    public void MarkBusy()
+    {
+        IsAvailable = false;
+    }
+
+    public void MarkAvailable()
+    {
+        IsAvailable = true;
+    }
+}

--- a/src/UserTasks.Api/Models/UserTask.cs
+++ b/src/UserTasks.Api/Models/UserTask.cs
@@ -1,0 +1,3 @@
+namespace UserTasks.Api.Models;
+
+public record UserTask(Guid Id, string Title, string Description, DateTime DueDate, bool IsCompleted);

--- a/src/UserTasks.Api/Program.cs
+++ b/src/UserTasks.Api/Program.cs
@@ -6,6 +6,7 @@ using UserTasks.Api.Services;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddSingleton<InMemoryDataStore>();
+builder.Services.AddSingleton<TaskAssignmentService>();
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();

--- a/src/UserTasks.Api/Program.cs
+++ b/src/UserTasks.Api/Program.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using UserTasks.Api.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddSingleton<InMemoryDataStore>();
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+app.UseAuthorization();
+app.MapControllers();
+
+app.Run();

--- a/src/UserTasks.Api/Services/InMemoryDataStore.cs
+++ b/src/UserTasks.Api/Services/InMemoryDataStore.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using UserTasks.Api.Models;
+
+namespace UserTasks.Api.Services;
+
+public class InMemoryDataStore
+{
+    private readonly List<UserTask> _tasks = new();
+    private bool _isSeeded;
+
+    public IReadOnlyCollection<UserTask> Tasks => _tasks.AsReadOnly();
+
+    public bool SeedInitialData()
+    {
+        if (_isSeeded)
+        {
+            return false;
+        }
+
+        _tasks.Clear();
+        _tasks.AddRange(new[]
+        {
+            new UserTask(Guid.NewGuid(), "Write API docs", "Document the seedTestData endpoint", DateTime.UtcNow.AddDays(1), false),
+            new UserTask(Guid.NewGuid(), "Create demo user", "Add a sample user for testing", DateTime.UtcNow.AddDays(2), false),
+            new UserTask(Guid.NewGuid(), "Schedule reminder", "Configure reminder notifications", DateTime.UtcNow.AddDays(3), false)
+        });
+
+        _isSeeded = true;
+        return true;
+    }
+}

--- a/src/UserTasks.Api/Services/InMemoryDataStore.cs
+++ b/src/UserTasks.Api/Services/InMemoryDataStore.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UserTasks.Api.Models;
 
 namespace UserTasks.Api.Services;
@@ -7,9 +8,74 @@ namespace UserTasks.Api.Services;
 public class InMemoryDataStore
 {
     private readonly List<UserTask> _tasks = new();
+    private readonly List<UserAccount> _users = new();
+    private readonly List<TaskAssignment> _taskAssignments = new();
+    private readonly Queue<TaskAssignment> _queuedAssignments = new();
     private bool _isSeeded;
 
     public IReadOnlyCollection<UserTask> Tasks => _tasks.AsReadOnly();
+    public IList<UserAccount> Users => _users;
+    public IList<TaskAssignment> TaskAssignments => _taskAssignments;
+    public IReadOnlyCollection<TaskAssignment> QueuedAssignments => _queuedAssignments.ToArray();
+
+    public void AddUser(UserAccount user)
+    {
+        if (user is null)
+        {
+            throw new ArgumentNullException(nameof(user));
+        }
+
+        if (_users.Any(existing => existing.Id == user.Id))
+        {
+            return;
+        }
+
+        _users.Add(user);
+    }
+
+    public void AddTaskAssignment(TaskAssignment assignment)
+    {
+        if (assignment is null)
+        {
+            throw new ArgumentNullException(nameof(assignment));
+        }
+
+        if (_taskAssignments.Any(existing => existing.Id == assignment.Id))
+        {
+            return;
+        }
+
+        _taskAssignments.Add(assignment);
+    }
+
+    public void EnqueueAssignment(TaskAssignment assignment)
+    {
+        if (assignment is null)
+        {
+            throw new ArgumentNullException(nameof(assignment));
+        }
+
+        if (_queuedAssignments.Contains(assignment))
+        {
+            return;
+        }
+
+        _queuedAssignments.Enqueue(assignment);
+    }
+
+    public TaskAssignment? DequeueNextQueuedAssignment()
+    {
+        while (_queuedAssignments.Count > 0)
+        {
+            var next = _queuedAssignments.Dequeue();
+            if (next.State == TaskState.Pending)
+            {
+                return next;
+            }
+        }
+
+        return null;
+    }
 
     public bool SeedInitialData()
     {
@@ -19,12 +85,24 @@ public class InMemoryDataStore
         }
 
         _tasks.Clear();
+        _taskAssignments.Clear();
+        _queuedAssignments.Clear();
         _tasks.AddRange(new[]
         {
             new UserTask(Guid.NewGuid(), "Write API docs", "Document the seedTestData endpoint", DateTime.UtcNow.AddDays(1), false),
             new UserTask(Guid.NewGuid(), "Create demo user", "Add a sample user for testing", DateTime.UtcNow.AddDays(2), false),
             new UserTask(Guid.NewGuid(), "Schedule reminder", "Configure reminder notifications", DateTime.UtcNow.AddDays(3), false)
         });
+
+        if (_users.Count == 0)
+        {
+            _users.AddRange(new[]
+            {
+                new UserAccount(Guid.NewGuid(), "Alex"),
+                new UserAccount(Guid.NewGuid(), "Bailey"),
+                new UserAccount(Guid.NewGuid(), "Cameron")
+            });
+        }
 
         _isSeeded = true;
         return true;

--- a/src/UserTasks.Api/Services/TaskAssignmentService.cs
+++ b/src/UserTasks.Api/Services/TaskAssignmentService.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Linq;
+using UserTasks.Api.Models;
+
+namespace UserTasks.Api.Services;
+
+public class TaskAssignmentService
+{
+    private readonly InMemoryDataStore _dataStore;
+
+    public TaskAssignmentService(InMemoryDataStore dataStore)
+    {
+        _dataStore = dataStore;
+    }
+
+    public UserAccount RegisterUser(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException("Name is required.", nameof(name));
+        }
+
+        var user = new UserAccount(Guid.NewGuid(), name.Trim());
+        _dataStore.AddUser(user);
+
+        var queuedTask = _dataStore.DequeueNextQueuedAssignment();
+        if (queuedTask is not null)
+        {
+            queuedTask.AssignTo(user.Id);
+            user.MarkBusy();
+        }
+
+        return user;
+    }
+
+    public OperationResult<TaskAssignment> CreateTask(string title, string description)
+    {
+        TaskAssignment assignment;
+        try
+        {
+            assignment = new TaskAssignment(Guid.NewGuid(), title, description);
+        }
+        catch (ArgumentException ex)
+        {
+            return OperationResult<TaskAssignment>.Failure(ex.Message);
+        }
+
+        var availableUser = _dataStore.Users.FirstOrDefault(user => user.IsAvailable);
+
+        if (availableUser is not null)
+        {
+            assignment.AssignTo(availableUser.Id);
+            availableUser.MarkBusy();
+        }
+        else
+        {
+            assignment.MarkPending();
+            _dataStore.EnqueueAssignment(assignment);
+        }
+
+        _dataStore.AddTaskAssignment(assignment);
+
+        return OperationResult<TaskAssignment>.Successful(assignment);
+    }
+
+    public OperationResult<TaskAssignment> CompleteTask(Guid taskId)
+    {
+        var assignment = _dataStore.TaskAssignments.FirstOrDefault(task => task.Id == taskId);
+        if (assignment is null)
+        {
+            return OperationResult<TaskAssignment>.Failure($"Task '{taskId}' was not found.");
+        }
+
+        if (assignment.State == TaskState.Completed)
+        {
+            return OperationResult<TaskAssignment>.Failure("Task is already completed.");
+        }
+
+        if (assignment.State != TaskState.InProgress)
+        {
+            return OperationResult<TaskAssignment>.Failure("Only in-progress tasks can be completed.");
+        }
+
+        assignment.Complete();
+
+        if (assignment.AssignedUserId is Guid userId)
+        {
+            var user = _dataStore.Users.FirstOrDefault(candidate => candidate.Id == userId);
+            if (user is not null)
+            {
+                user.MarkAvailable();
+
+                var nextTask = _dataStore.DequeueNextQueuedAssignment();
+                if (nextTask is not null)
+                {
+                    nextTask.AssignTo(user.Id);
+                    user.MarkBusy();
+                }
+            }
+        }
+
+        return OperationResult<TaskAssignment>.Successful(assignment);
+    }
+}

--- a/src/UserTasks.Api/UserTasks.Api.csproj
+++ b/src/UserTasks.Api/UserTasks.Api.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add models for task assignments, task state, operation results, and user accounts
- implement a task assignment service that assigns users when available and queues tasks otherwise
- extend the in-memory store to track users, assignments, and queues while registering the new service with dependency injection

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68db72d70c9c832090f2b0c2ea9a82ef