### PR TITLE
Add API endpoint to seed in-memory test data on demand

### DIFF
--- a/TaskRotationApi/Controllers/SeedTestDataController.cs
+++ b/TaskRotationApi/Controllers/SeedTestDataController.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Mvc;
+using TaskRotationApi.Storage;
+
+namespace TaskRotationApi.Controllers;
+
+[ApiController]
+[Route("api/seedTestData")]
+public class SeedTestDataController(InMemoryDataStore dataStore) : ControllerBase
+{
+    /// <summary>
+    ///     Seeds the in-memory data store with default test data.
+    /// </summary>
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public IActionResult Seed()
+    {
+        var seeded = dataStore.SeedInitialData();
+        return Ok(new { seeded });
+    }
+}

--- a/TaskRotationApi/Storage/InMemoryDataStore.cs
+++ b/TaskRotationApi/Storage/InMemoryDataStore.cs
@@ -38,58 +38,63 @@ public class InMemoryDataStore
         }
     }
 
-    private void SeedInitialData()
+    public bool SeedInitialData()
     {
-        if (_users.Count != 0 || _tasks.Count != 0) return;
-
-        string[] defaultUsers =
+        lock (_sync)
         {
-            "Liam",
-            "Noah",
-            "Oliver",
-            "Theodore",
-            "James",
-            "Henry",
-            "Mateo",
-            "Elijah",
-            "Lucas",
-            "William"
-        };
+            if (_users.Count != 0 || _tasks.Count != 0) return false;
 
-        foreach (var name in defaultUsers)
-            _users.Add(new User
+            string[] defaultUsers =
             {
-                Name = name
-            });
+                "Liam",
+                "Noah",
+                "Oliver",
+                "Theodore",
+                "James",
+                "Henry",
+                "Mateo",
+                "Elijah",
+                "Lucas",
+                "William"
+            };
 
-        string[] defaultTasks =
-        {
-            "Ride",
-            "Sit down",
-            "Win",
-            "Drink",
-            "Knit",
-            "Stand",
-            "Throw",
-            "Close",
-            "Open",
-            "Skip",
-            "Sleep",
-            "Cut",
-            "Eat",
-            "Cook",
-            "Sip",
-            "Fight",
-            "Play",
-            "Give",
-            "Dig",
-            "Bath"
-        };
+            foreach (var name in defaultUsers)
+                _users.Add(new User
+                {
+                    Name = name
+                });
 
-        foreach (var title in defaultTasks)
-            _tasks.Add(new TaskItem
+            string[] defaultTasks =
             {
-                Title = title
-            });
+                "Ride",
+                "Sit down",
+                "Win",
+                "Drink",
+                "Knit",
+                "Stand",
+                "Throw",
+                "Close",
+                "Open",
+                "Skip",
+                "Sleep",
+                "Cut",
+                "Eat",
+                "Cook",
+                "Sip",
+                "Fight",
+                "Play",
+                "Give",
+                "Dig",
+                "Bath"
+            };
+
+            foreach (var title in defaultTasks)
+                _tasks.Add(new TaskItem
+                {
+                    Title = title
+                });
+
+            return true;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- expose a thread-safe `SeedInitialData` method on the in-memory data store
- add a controller endpoint at `api/seedTestData` to invoke seeding when requested

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68db76c409ac8320b4caf28a50cd7d4f