### PR TITLE
Add XML documentation to core services and controllers

### DIFF
--- a/TaskRotationApi/Controllers/SeedTestDataController.cs
+++ b/TaskRotationApi/Controllers/SeedTestDataController.cs
@@ -5,6 +5,9 @@ namespace TaskRotationApi.Controllers;
 
 [ApiController]
 [Route("api/seedTestData")]
+/// <summary>
+///     Offers an endpoint for populating the in-memory store with sample data.
+/// </summary>
 public class SeedTestDataController(InMemoryDataStore dataStore) : ControllerBase
 {
     /// <summary>

--- a/TaskRotationApi/Controllers/TasksController.cs
+++ b/TaskRotationApi/Controllers/TasksController.cs
@@ -6,6 +6,9 @@ namespace TaskRotationApi.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
+/// <summary>
+///     Provides endpoints for inspecting and creating tasks in the rotation system.
+/// </summary>
 public class TasksController(TaskAssignmentService service) : ControllerBase
 {
     /// <summary>
@@ -48,6 +51,12 @@ public class TasksController(TaskAssignmentService service) : ControllerBase
         return CreatedAtAction(nameof(GetTask), new { id = result.Value!.Id }, result.Value);
     }
 
+    /// <summary>
+    ///     Converts a <see cref="ServiceResult"/> to a typed HTTP response.
+    /// </summary>
+    /// <typeparam name="T">The expected payload type.</typeparam>
+    /// <param name="result">The operation outcome to translate.</param>
+    /// <returns>The HTTP representation of the <paramref name="result"/>.</returns>
     private static ActionResult<T> MapError<T>(ServiceResult result)
     {
         return result.Code switch
@@ -60,6 +69,11 @@ public class TasksController(TaskAssignmentService service) : ControllerBase
         };
     }
 
+    /// <summary>
+    ///     Converts a non-generic <see cref="ServiceResult"/> to an HTTP response.
+    /// </summary>
+    /// <param name="result">The operation outcome to translate.</param>
+    /// <returns>The HTTP representation of the <paramref name="result"/>.</returns>
     private static IActionResult MapError(ServiceResult result)
     {
         return result.Code switch

--- a/TaskRotationApi/Controllers/UsersController.cs
+++ b/TaskRotationApi/Controllers/UsersController.cs
@@ -6,6 +6,9 @@ namespace TaskRotationApi.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
+/// <summary>
+///     Exposes endpoints for managing users participating in task rotation.
+/// </summary>
 public class UsersController(TaskAssignmentService service) : ControllerBase
 {
     /// <summary>
@@ -63,6 +66,12 @@ public class UsersController(TaskAssignmentService service) : ControllerBase
         return NoContent();
     }
 
+    /// <summary>
+    ///     Maps a <see cref="ServiceResult"/> to an HTTP response with a typed payload.
+    /// </summary>
+    /// <typeparam name="T">The expected response body type.</typeparam>
+    /// <param name="result">The operation outcome to convert.</param>
+    /// <returns>An HTTP result representing the provided <paramref name="result"/>.</returns>
     private static ActionResult<T> MapError<T>(ServiceResult result)
     {
         return result.Code switch
@@ -75,6 +84,11 @@ public class UsersController(TaskAssignmentService service) : ControllerBase
         };
     }
 
+    /// <summary>
+    ///     Maps a <see cref="ServiceResult"/> without payload to an HTTP response.
+    /// </summary>
+    /// <param name="result">The operation outcome to convert.</param>
+    /// <returns>An HTTP result representing the provided <paramref name="result"/>.</returns>
     private static IActionResult MapError(ServiceResult result)
     {
         return result.Code switch

--- a/TaskRotationApi/Dtos/TaskRotationOptions.cs
+++ b/TaskRotationApi/Dtos/TaskRotationOptions.cs
@@ -1,6 +1,12 @@
 ﻿namespace TaskRotationApi.Dtos;
 
+/// <summary>
+///     Configuration options governing the automated task rotation interval.
+/// </summary>
 public sealed class TaskRotationOptions
 {
+    /// <summary>
+    ///     Gets or sets the number of seconds between automatic task rotations.
+    /// </summary>
     public int IntervalSeconds { get; set; } = 120;
 }

--- a/TaskRotationApi/Services/ServiceResult.cs
+++ b/TaskRotationApi/Services/ServiceResult.cs
@@ -1,5 +1,8 @@
 namespace TaskRotationApi.Services;
 
+/// <summary>
+///     Represents the type of error returned by domain operations.
+/// </summary>
 public enum ErrorCode
 {
     None = 0,
@@ -9,26 +12,54 @@ public enum ErrorCode
     LimitReached
 }
 
+/// <summary>
+///     Encapsulates the outcome of an operation returning a value.
+/// </summary>
+/// <typeparam name="T">The type of the value produced by the operation.</typeparam>
 public readonly record struct ServiceResult<T>(bool Success, ErrorCode Code, string? Error, T? Value)
 {
+    /// <summary>
+    ///     Creates a successful <see cref="ServiceResult{T}"/>.
+    /// </summary>
+    /// <param name="value">The resulting value of the operation.</param>
+    /// <returns>A successful service result containing the provided value.</returns>
     public static ServiceResult<T> SuccessResult(T value)
     {
         return new ServiceResult<T>(true, ErrorCode.None, null, value);
     }
 
+    /// <summary>
+    ///     Creates a failed <see cref="ServiceResult{T}"/>.
+    /// </summary>
+    /// <param name="code">The error code describing the failure.</param>
+    /// <param name="message">A human readable message explaining the failure.</param>
+    /// <returns>A failed service result.</returns>
     public static ServiceResult<T> Failure(ErrorCode code, string message)
     {
         return new ServiceResult<T>(false, code, message, default);
     }
 }
 
+/// <summary>
+///     Encapsulates the outcome of an operation that does not produce a value.
+/// </summary>
 public readonly record struct ServiceResult(bool Success, ErrorCode Code, string? Error)
 {
+    /// <summary>
+    ///     Creates a successful <see cref="ServiceResult"/>.
+    /// </summary>
+    /// <returns>A successful service result.</returns>
     public static ServiceResult SuccessResult()
     {
         return new ServiceResult(true, ErrorCode.None, null);
     }
 
+    /// <summary>
+    ///     Creates a failed <see cref="ServiceResult"/>.
+    /// </summary>
+    /// <param name="code">The error code describing the failure.</param>
+    /// <param name="message">A human readable message explaining the failure.</param>
+    /// <returns>A failed service result.</returns>
     public static ServiceResult Failure(ErrorCode code, string message)
     {
         return new ServiceResult(false, code, message);

--- a/TaskRotationApi/Services/TaskRotationHostedService.cs
+++ b/TaskRotationApi/Services/TaskRotationHostedService.cs
@@ -9,6 +9,12 @@ public class TaskRotationHostedService : BackgroundService
     private readonly ILogger<TaskRotationHostedService> _logger;
     private readonly TaskAssignmentService _service;
 
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="TaskRotationHostedService"/> class.
+    /// </summary>
+    /// <param name="service">The domain service used to rotate tasks.</param>
+    /// <param name="logger">Logger used to emit diagnostic messages.</param>
+    /// <param name="configuration">Configuration source for rotation options.</param>
     public TaskRotationHostedService(TaskAssignmentService service, ILogger<TaskRotationHostedService> logger,
         IConfiguration configuration)
     {
@@ -22,6 +28,10 @@ public class TaskRotationHostedService : BackgroundService
         _interval = TimeSpan.FromSeconds(seconds);
     }
 
+    /// <summary>
+    ///     Executes the background rotation loop until cancellation is requested.
+    /// </summary>
+    /// <param name="stoppingToken">Token signalling when the host is shutting down.</param>
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         _logger.LogInformation("Task rotation service started. Interval: {Interval}", _interval);
@@ -40,6 +50,9 @@ public class TaskRotationHostedService : BackgroundService
         }
     }
 
+    /// <summary>
+    ///     Safely executes a rotation cycle while handling unexpected exceptions.
+    /// </summary>
     private void SafeRotate()
     {
         try

--- a/TaskRotationApi/Storage/InMemoryDataStore.cs
+++ b/TaskRotationApi/Storage/InMemoryDataStore.cs
@@ -12,6 +12,12 @@ public class InMemoryDataStore
     private readonly List<TaskItem> _tasks = [];
     private readonly List<User> _users = [];
 
+    /// <summary>
+    ///     Reads data from the store using a delegate while holding a lock.
+    /// </summary>
+    /// <typeparam name="T">The type returned by the delegate.</typeparam>
+    /// <param name="reader">The function that consumes copies of the current users and tasks.</param>
+    /// <returns>The value returned by the <paramref name="reader"/> delegate.</returns>
     public T Read<T>(Func<IReadOnlyList<User>, IReadOnlyList<TaskItem>, T> reader)
     {
         lock (_sync)
@@ -22,6 +28,10 @@ public class InMemoryDataStore
         }
     }
 
+    /// <summary>
+    ///     Executes a write action under a lock to mutate the underlying collections.
+    /// </summary>
+    /// <param name="writer">The action that performs updates on the shared collections.</param>
     public void Write(Action<List<User>, List<TaskItem>> writer)
     {
         lock (_sync)
@@ -30,6 +40,12 @@ public class InMemoryDataStore
         }
     }
 
+    /// <summary>
+    ///     Executes a write function under a lock and returns its result.
+    /// </summary>
+    /// <typeparam name="T">The type returned by the <paramref name="writer"/> delegate.</typeparam>
+    /// <param name="writer">The function that performs updates on the shared collections.</param>
+    /// <returns>The value produced by the <paramref name="writer"/> delegate.</returns>
     public T Write<T>(Func<List<User>, List<TaskItem>, T> writer)
     {
         lock (_sync)
@@ -38,6 +54,10 @@ public class InMemoryDataStore
         }
     }
 
+    /// <summary>
+    ///     Seeds the store with a predefined set of users and tasks if empty.
+    /// </summary>
+    /// <returns><c>true</c> if data was seeded; otherwise, <c>false</c>.</returns>
     public bool SeedInitialData()
     {
         lock (_sync)


### PR DESCRIPTION
## Summary
- add XML documentation comments to the API controllers and supporting services
- describe service result helpers and in-memory store operations for easier discovery

## Testing
- dotnet test *(fails: `dotnet` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbfd2a8328832086a9eb39171ad418