### PR TITLE
Add XML documentation to eliminate analyzer warnings

### DIFF
--- a/TaskRotationApi/Controllers/SeedTestDataController.cs
+++ b/TaskRotationApi/Controllers/SeedTestDataController.cs
@@ -8,6 +8,7 @@ namespace TaskRotationApi.Controllers;
 /// <summary>
 ///     Offers an endpoint for populating the in-memory store with sample data.
 /// </summary>
+/// <param name="dataStore">In-memory storage used to seed default data.</param>
 public class SeedTestDataController(InMemoryDataStore dataStore) : ControllerBase
 {
     /// <summary>

--- a/TaskRotationApi/Controllers/TasksController.cs
+++ b/TaskRotationApi/Controllers/TasksController.cs
@@ -9,6 +9,7 @@ namespace TaskRotationApi.Controllers;
 /// <summary>
 ///     Provides endpoints for inspecting and creating tasks in the rotation system.
 /// </summary>
+/// <param name="service">Domain service used for task operations.</param>
 public class TasksController(TaskAssignmentService service) : ControllerBase
 {
     /// <summary>

--- a/TaskRotationApi/Controllers/UsersController.cs
+++ b/TaskRotationApi/Controllers/UsersController.cs
@@ -9,6 +9,7 @@ namespace TaskRotationApi.Controllers;
 /// <summary>
 ///     Exposes endpoints for managing users participating in task rotation.
 /// </summary>
+/// <param name="service">Domain service used for user operations.</param>
 public class UsersController(TaskAssignmentService service) : ControllerBase
 {
     /// <summary>

--- a/TaskRotationApi/Dtos/TaskDtos.cs
+++ b/TaskRotationApi/Dtos/TaskDtos.cs
@@ -3,12 +3,27 @@ using TaskRotationApi.Models;
 
 namespace TaskRotationApi.Dtos;
 
+/// <summary>
+///     Request payload used to create a task within the API.
+/// </summary>
+/// <param name="Title">The desired title of the task.</param>
 public record CreateTaskRequest(
     [Required]
     [StringLength(100, MinimumLength = 1)]
     string Title
 );
 
+/// <summary>
+///     Response payload that describes a task and its assignment metadata.
+/// </summary>
+/// <param name="Id">The unique identifier of the task.</param>
+/// <param name="Title">The descriptive title of the task.</param>
+/// <param name="State">The current processing state of the task.</param>
+/// <param name="AssignedUserId">The identifier of the user currently assigned to the task.</param>
+/// <param name="AssignedUserName">The display name of the user currently assigned to the task.</param>
+/// <param name="VisitedUsersCount">Number of distinct users that have been assigned the task.</param>
+/// <param name="AssignmentHistory">Chronological list of users that have received the task.</param>
+/// <param name="CreatedAt">Timestamp of when the task was created.</param>
 public record TaskResponse(
     Guid Id,
     string Title,

--- a/TaskRotationApi/Dtos/TaskRotationOptions.cs
+++ b/TaskRotationApi/Dtos/TaskRotationOptions.cs
@@ -10,3 +10,4 @@ public sealed class TaskRotationOptions
     /// </summary>
     public int IntervalSeconds { get; set; } = 120;
 }
+

--- a/TaskRotationApi/Dtos/UserDtos.cs
+++ b/TaskRotationApi/Dtos/UserDtos.cs
@@ -2,10 +2,21 @@ using System.ComponentModel.DataAnnotations;
 
 namespace TaskRotationApi.Dtos;
 
+/// <summary>
+///     Request payload used to register a new user.
+/// </summary>
+/// <param name="Name">Display name for the new user.</param>
 public record CreateUserRequest(
     [Required]
     [StringLength(50, MinimumLength = 1)]
     string Name
 );
 
+/// <summary>
+///     Response payload describing a user and assignment statistics.
+/// </summary>
+/// <param name="Id">The unique identifier of the user.</param>
+/// <param name="Name">The display name of the user.</param>
+/// <param name="ActiveTasksCount">Number of tasks currently assigned to the user.</param>
+/// <param name="TotalTasksAssigned">Total number of tasks that have been assigned to the user.</param>
 public record UserResponse(Guid Id, string Name, int ActiveTasksCount, int TotalTasksAssigned);

--- a/TaskRotationApi/Models/TaskItem.cs
+++ b/TaskRotationApi/Models/TaskItem.cs
@@ -5,17 +5,38 @@ namespace TaskRotationApi.Models;
 /// </summary>
 public class TaskItem
 {
+    /// <summary>
+    ///     Gets the unique identifier for the task.
+    /// </summary>
     public Guid Id { get; init; } = Guid.NewGuid();
 
+    /// <summary>
+    ///     Gets or sets the descriptive title of the task.
+    /// </summary>
     public required string Title { get; set; }
 
+    /// <summary>
+    ///     Gets or sets the current state of the task.
+    /// </summary>
     public TaskState State { get; set; } = TaskState.Waiting;
 
+    /// <summary>
+    ///     Gets or sets the identifier of the user currently assigned to the task.
+    /// </summary>
     public Guid? AssignedUserId { get; set; }
 
+    /// <summary>
+    ///     Gets or sets the identifier of the user that was most recently assigned before the current one.
+    /// </summary>
     public Guid? PreviousUserId { get; set; }
 
+    /// <summary>
+    ///     Gets the chronological list of users that have been assigned to the task.
+    /// </summary>
     public List<Guid> AssignmentHistory { get; } = [];
 
+    /// <summary>
+    ///     Gets the timestamp of when the task was created.
+    /// </summary>
     public DateTimeOffset CreatedAt { get; } = DateTimeOffset.UtcNow;
 }

--- a/TaskRotationApi/Models/TaskState.cs
+++ b/TaskRotationApi/Models/TaskState.cs
@@ -1,8 +1,22 @@
 namespace TaskRotationApi.Models;
 
+/// <summary>
+///     Enumerates the possible lifecycle states of a task.
+/// </summary>
 public enum TaskState
 {
+    /// <summary>
+    ///     The task is waiting for an available user.
+    /// </summary>
     Waiting = 0,
+
+    /// <summary>
+    ///     The task is currently assigned to a user.
+    /// </summary>
     InProgress = 1,
+
+    /// <summary>
+    ///     The task has completed its rotation and no longer needs processing.
+    /// </summary>
     Completed = 2
 }

--- a/TaskRotationApi/Models/User.cs
+++ b/TaskRotationApi/Models/User.cs
@@ -5,7 +5,13 @@ namespace TaskRotationApi.Models;
 /// </summary>
 public class User
 {
+    /// <summary>
+    ///     Gets the unique identifier for the user.
+    /// </summary>
     public Guid Id { get; init; } = Guid.NewGuid();
 
+    /// <summary>
+    ///     Gets or sets the display name of the user.
+    /// </summary>
     public required string Name { get; set; }
 }


### PR DESCRIPTION
## Summary
- add XML documentation for controllers, DTOs, and models to satisfy analyzers
- annotate primary constructors with parameter documentation to remove CS1573 warnings
- document model members and enums so XML doc generation succeeds without warnings

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dbff1e82c08320b77f3209bc7d81d8